### PR TITLE
Use dflydev/apache-mime-types for parsing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
 		}
 	],
 	"require": {
-		"php": ">=5.2"
+		"php": ">=5.2",
+		"dflydev/apache-mime-types": "1.0.*@dev"
 	},
 	"type": "library"
 }

--- a/generate
+++ b/generate
@@ -24,30 +24,10 @@
  * <http://opensource.org/licenses/MIT>
  */
 
-$lines = file(__DIR__ . '/mime.types', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-$mimes = array();
+require(__DIR__ . '/vendor/autoload.php');
 
-
-##################################################################################
-# PARSE TEXT INTO A LOGICAL DATA STRUCTURE
-
-foreach ($lines as $k => &$line)
-{
-	if (strpos($line, '#') !== 0)
-	{
-		preg_match_all('/^((\w|\/|\.|-|\+)+)(\s+)([^\n]*)$/im', $line, $match);
-		$type = $match[1][0];
-		$extensions = explode(' ', $match[4][0]);
-
-		foreach ($extensions as $extension)
-		{
-			if (!isset($mimes[$extension]))
-			{
-				$mimes[$extension] = $type;
-			}
-		}
-	}
-}
+$repository = new Dflydev\ApacheMimeTypes\FlatRepository(__DIR__ . '/mime.types');
+$mimes = $repository->dumpExtensionToType();
 
 
 ##################################################################################


### PR DESCRIPTION
I can also remove `mime.types` and have it use the internal `mime.types` from the other package. If I did that, the only change would be:

```
$repository = new Dflydev\ApacheMimeTypes\FlatRepository;
```

I did some tests to ensure that it generated the same output. You can verify yourself. :)
