### PR TITLE
Fix autoloading when installed as a dependency

### DIFF
--- a/generate
+++ b/generate
@@ -24,7 +24,19 @@
  * <http://opensource.org/licenses/MIT>
  */
 
-require(__DIR__ . '/vendor/autoload.php');
+$nonDependencyPath = __DIR__ . '/vendor/autoload.php';
+
+if (!is_file($nonDependencyPath)) {
+    $dependencyPath = __DIR__ . '/../../autoload.php';
+    if (!is_file($dependencyPath)) {
+        echo "Cannot find composer, please run a composer updated before continuing." . PHP_EOL;
+        exit(1);
+    } else {
+        require($dependencyPath);
+    }
+} else {
+    require($nonDependencyPath);
+}
 
 $repository = new Dflydev\ApacheMimeTypes\FlatRepository(__DIR__ . '/mime.types');
 $mimes = $repository->dumpExtensionToType();


### PR DESCRIPTION
Previously, when the project was installed as a dependency through composer the `generate` script could not find the autoloader.

This commit resolves that by checking whether the autoloader exists in the current directory (i.e. not as a dependency) or whether the autoloader exists two directories up (i.e. as a dependency). If neither of these paths exist the script will gracefully fail.
